### PR TITLE
ci: drop loss_trace quickcheck – dataset unavailable on runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,9 +40,6 @@ jobs:
       - name: Gradcheck
         run: make -C COMP36212_EX3_Code gradcheck || true
 
-      - name: Loss-trace quickcheck
-        run: make -C COMP36212_EX3_Code quickcheck
-
       - name: Plot scripts
         run: make -C COMP36212_EX3_Code plot
 


### PR DESCRIPTION
Remove loss-trace quickcheck from CI — dataset not present on runne